### PR TITLE
[!] 修复 macOS 10.13.6 下不能获取到 VendorID,ProductID,EDID 问题

### DIFF
--- a/hidpi-zh.sh
+++ b/hidpi-zh.sh
@@ -16,9 +16,9 @@ cat << EEF
 ============================================
 EEF
     #
-    VendorID=$(ioreg -l | grep "DisplayVendorID" | awk '{print $8}')
-    ProductID=$(ioreg -l | grep "DisplayProductID" | awk '{print $8}')
-    EDID=$(ioreg -l | grep "IODisplayEDID" | awk '{print $8}' | sed -e 's/.$//' -e 's/^.//')
+    VendorID=$(ioreg -l | grep "DisplayVendorID" | awk '{print $NF}')
+    ProductID=$(ioreg -l | grep "DisplayProductID" | awk '{print $NF}')
+    EDID=$(ioreg -l | grep "IODisplayEDID" | awk '{print $NF}' | sed -e 's/.$//' -e 's/^.//')
 
     Vid=$(echo "obase=16;$VendorID" | bc | tr 'A-Z' 'a-z')
     Pid=$(echo "obase=16;$ProductID" | bc | tr 'A-Z' 'a-z')

--- a/hidpi.sh
+++ b/hidpi.sh
@@ -16,9 +16,9 @@ cat << EEF
 ============================================
 EEF
     #
-    VendorID=$(ioreg -l | grep "DisplayVendorID" | awk '{print $8}')
-    ProductID=$(ioreg -l | grep "DisplayProductID" | awk '{print $8}')
-    EDID=$(ioreg -l | grep "IODisplayEDID" | awk '{print $8}' | sed -e 's/.$//' -e 's/^.//')
+    VendorID=$(ioreg -l | grep "DisplayVendorID" | awk '{print $NF}')
+    ProductID=$(ioreg -l | grep "DisplayProductID" | awk '{print $NF}')
+    EDID=$(ioreg -l | grep "IODisplayEDID" | awk '{print $NF}' | sed -e 's/.$//' -e 's/^.//')
 
     Vid=$(echo "obase=16;$VendorID" | bc | tr 'A-Z' 'a-z')
     Pid=$(echo "obase=16;$ProductID" | bc | tr 'A-Z' 'a-z')


### PR DESCRIPTION
☁  ~  ioreg -l | grep "DisplayVendorID" | awk '{print $NF}'
4268
☁  ~  ioreg -l | grep "DisplayVendorID" | awk '{print $8}'
=
☁  ~