### PR TITLE
 Choose the right sed -i command in case machine uses different version of sed

### DIFF
--- a/hidpi-zh.sh
+++ b/hidpi-zh.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
-# 
+#
+
+function sedi()
+{
+    sed --version >/dev/null 2>&1 && sed -i "$@" || sed -i "" "$@"
+}
+
 # 初始化
 function init()
 {
@@ -93,14 +99,14 @@ exit 0
 esac 
 
 if [[ $Picon ]]; then
-    sed -i '' "s/VID/$Vid/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/PID/$Pid/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPX/${RP[0]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPY/${RP[1]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPW/${RP[2]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPH/${RP[3]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/PICON/$Picon/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/DICON/$DICON/g" $thisDir/tmp/Icons.plist
+    sedi "s/VID/$Vid/g" $thisDir/tmp/Icons.plist
+    sedi "s/PID/$Pid/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPX/${RP[0]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPY/${RP[1]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPW/${RP[2]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPH/${RP[3]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/PICON/$Picon/g" $thisDir/tmp/Icons.plist
+    sedi "s/DICON/$DICON/g" $thisDir/tmp/Icons.plist
 fi
 
 }
@@ -162,8 +168,8 @@ cat >> "$dpiFile" <<-\FFF
 </plist>
 FFF
 
-    sed -i '' "s/VID/$VendorID/g" $dpiFile
-    sed -i '' "s/PID/$ProductID/g" $dpiFile
+    sedi "s/VID/$VendorID/g" $dpiFile
+    sedi "s/PID/$ProductID/g" $dpiFile
 }
 
 # 擦屁股
@@ -256,8 +262,8 @@ function enable_hidpi()
 {
     choose_icon
     main
-    sed -i "" "/.*IODisplayEDID/d" $dpiFile
-    sed -i "" "/.*EDid/d" $dpiFile
+    sedi "/.*IODisplayEDID/d" $dpiFile
+    sedi "/.*EDid/d" $dpiFile
     end
 }
 
@@ -266,7 +272,7 @@ function enable_hidpi_with_patch()
 {
     choose_icon
     main
-    sed -i '' "s:EDid:${EDid}:g" $dpiFile
+    sedi "s:EDid:${EDid}:g" $dpiFile
     end
 }
 

--- a/hidpi.sh
+++ b/hidpi.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
-# 
+#
+
+function sedi()
+{
+    sed --version >/dev/null 2>&1 && sed -i "$@" || sed -i "" "$@"
+}
+
 # init
 function init()
 {
@@ -91,14 +97,14 @@ exit 0
 esac 
 
 if [[ $Picon ]]; then
-    sed -i '' "s/VID/$Vid/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/PID/$Pid/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPX/${RP[0]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPY/${RP[1]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPW/${RP[2]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/RPH/${RP[3]}/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/PICON/$Picon/g" $thisDir/tmp/Icons.plist
-    sed -i '' "s/DICON/$DICON/g" $thisDir/tmp/Icons.plist
+    sedi "s/VID/$Vid/g" $thisDir/tmp/Icons.plist
+    sedi "s/PID/$Pid/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPX/${RP[0]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPY/${RP[1]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPW/${RP[2]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/RPH/${RP[3]}/g" $thisDir/tmp/Icons.plist
+    sedi "s/PICON/$Picon/g" $thisDir/tmp/Icons.plist
+    sedi "s/DICON/$DICON/g" $thisDir/tmp/Icons.plist
 fi
 
 }
@@ -160,8 +166,8 @@ cat >> "$dpiFile" <<-\FFF
 </plist>
 FFF
 
-    sed -i '' "s/VID/$VendorID/g" $dpiFile
-    sed -i '' "s/PID/$ProductID/g" $dpiFile
+    sedi "s/VID/$VendorID/g" $dpiFile
+    sedi "s/PID/$ProductID/g" $dpiFile
 }
 
 # end
@@ -254,8 +260,8 @@ function enable_hidpi()
 {
     choose_icon
     main
-    sed -i "" "/.*IODisplayEDID/d" $dpiFile
-    sed -i "" "/.*EDid/d" $dpiFile
+    sedi "/.*IODisplayEDID/d" $dpiFile
+    sedi "/.*EDid/d" $dpiFile
     end
 }
 
@@ -264,7 +270,7 @@ function enable_hidpi_with_patch()
 {
     choose_icon
     main
-    sed -i '' "s:EDid:${EDid}:g" $dpiFile
+    sedi "s:EDid:${EDid}:g" $dpiFile
     end
 }
 


### PR DESCRIPTION
Hello, while i was using the tool after choosing what icon to use i got these errors:

`sed: can't read s/VID/30e4/g: No such file or directory
sed: can't read s/PID/470/g: No such file or directory
sed: can't read s/RPX/40/g: No such file or directory
sed: can't read s/RPY/62/g: No such file or directory
sed: can't read s/RPW/147/g: No such file or directory
sed: can't read s/RPH/92/g: No such file or directory
sed: can't read s/PICON/\/System\/Library\/Displays\/Contents\/Resources\/Overrides\/DisplayVendorID-610\/DisplayProductID-a030-e1e1df.tiff/g: No such file or directory
sed: can't read s/DICON/com\.apple\.cinema-display/g: No such file or directory`

So after checking the code i saw that it uses `sed -i ""` to replace the values in plist. But my machine is using the `gnu-sed` instead of the `macOS sed`, which doesn't work with the current command since `gnu-sed` uses `sed -i` instead of `sed -i ""`. So i implemented a function which chooses the right sed command based on the installed version. Doing that will be compatible with every machine that uses a different version than the default macOS one.

I know that's a workaround but i couldn't find a better solution and since that worked for me i thought i would share it.