### PR TITLE
修复SIP状态判断

### DIFF
--- a/hidpi.sh
+++ b/hidpi.sh
@@ -72,7 +72,7 @@ downloadHost="https://raw.githubusercontent.com/xzhih/one-key-hidpi/master"
 # downloadHost="https://raw.githubusercontent.com/xzhih/one-key-hidpi/dev"
 # downloadHost="http://127.0.0.1:8080"
 
-if [[ "${sipInfo}" == *"Filesystem Protections: disabled"* ]] || [[ "$(awk '{print $5}' <<< "${sipInfo}")" == "disabled." ]]; then
+if [[ "${sipInfo}" == *"Filesystem Protections: disabled"* ]] || [[ "$(awk '{print $5}' <<< "${sipInfo}")" == "disabled." ]] || [[ "$(awk '{print $5}' <<< "${sipInfo}")" == "disabled" ]]; then
     :
 else
     echo "${disableSIP}";


### PR DESCRIPTION
我发现某些情况下 `csrutil status` 返回值是 `System Integrity Protection status: disabled (Apple Internal).` 原因不详，这结果并不满足脚本对关闭SIP的判断。

![B72A1B4C11BA108EBC6EBC8F1F875D74](https://user-images.githubusercontent.com/12729036/79538559-2ec11e00-80b7-11ea-948b-fe424e06605b.jpg)
