### PR TITLE
Add 1920x1280 resolution

### DIFF
--- a/hidpi.sh
+++ b/hidpi.sh
@@ -44,9 +44,10 @@ langChooseRes="resolution config"
 langChooseResOp1="(1) 1920x1080 Display"
 langChooseResOp2="(2) 1920x1080 Display (use 1424x802, fix underscaled after sleep)"
 langChooseResOp3="(3) 1920x1200 Display"
-langChooseResOp4="(4) 2560x1440 Display"
-langChooseResOp5="(5) 3000x2000 Display"
-langChooseResOpCustom="(6) Manual input resolution"
+langChooseResOp4="(4) 1920x1280 Display"
+langChooseResOp5="(5) 2560x1440 Display"
+langChooseResOp6="(6) 3000x2000 Display"
+langChooseResOpCustom="(7) Manual input resolution"
 
 langNoMonitFound="No monitors were found. Exiting..."
 langMonitVIDPID="Your monitor VID:PID:"
@@ -80,9 +81,10 @@ if [[ "${systemLanguage}" == "zh_CN" ]]; then
     langChooseResOp1="(1) 1920x1080 显示屏"
     langChooseResOp2="(2) 1920x1080 显示屏 (使用 1424x802 分辨率，修复睡眠唤醒后的屏幕缩小问题)"
     langChooseResOp3="(3) 1920x1200 显示屏"
-    langChooseResOp4="(4) 2560x1440 显示屏"
-    langChooseResOp5="(5) 3000x2000 显示屏"
-    langChooseResOpCustom="(6) 手动输入分辨率"
+    langChooseResOp4="(4) 1920x1280 显示屏"
+    langChooseResOp5="(5) 2560x1440 显示屏"
+    langChooseResOp6="(6) 3000x2000 显示屏"
+    langChooseResOpCustom="(7) 手动输入分辨率"
 
     langNoMonitFound="没有找到监视器。 退出..."
     langMonitVIDPID="您的显示器 供应商ID:产品ID:"
@@ -116,9 +118,10 @@ elif [[ "${systemLanguage}" == "uk_UA" ]]; then
     langChooseResOp1="(1) 1920x1080 монітор"
     langChooseResOp2="(2) 1920x1080 монітор (використовувати 1424x802, виправлення заниженої роздільної здатності після сну)"
     langChooseResOp3="(3) 1920x1200 монітор"
-    langChooseResOp4="(4) 2560x1440 монітор"
-    langChooseResOp5="(5) 3000x2000 монітор"
-    langChooseResOpCustom="(6) Ввести роздільну здатність вручну"
+    langChooseResOp4="(4) 1920x1280 монітор"
+    langChooseResOp5="(5) 2560x1440 монітор"
+    langChooseResOp6="(6) 3000x2000 монітор"
+    langChooseResOpCustom="(7) Ввести роздільну здатність вручну"
 
     langNoMonitFound="Моніторів не знайдено. Завершую роботу..."
     langMonitVIDPID="ID Виробника:ID пристрою твого монітора:"
@@ -608,6 +611,7 @@ CCC
     echo ${langChooseResOp3}
     echo ${langChooseResOp4}
     echo ${langChooseResOp5}
+    echo ${langChooseResOp6}
     echo ${langChooseResOpCustom}
     echo ""
 
@@ -632,18 +636,24 @@ CCC
         create_res_4 1680x1050 1440x900 1280x800 1024x640 960x540 840x472 800x450 640x360
         ;;
     4)
+        create_res_1 1920x1280 1440x960 1280x854 1152x768
+        create_res_2 1280x800 1280x720 960x600 960x540 640x360
+        create_res_3 840x472 800x450 720x405 640x360 576x324 512x288 420x234 400x225 320x180
+        create_res_4 1920x1280 1680x1050 1440x900 1280x800 1024x640 960x540 840x472 800x450 640x360
+        ;;
+    5)
         create_res_1 2560x1440 2048x1152 1920x1080 1760x990 1680x945 1440x810 1360x765 1280x720
         create_res_2 1360x765 1280x800 1280x720 1024x576 960x600 960x540 640x360
         create_res_3 960x540 840x472 800x450 720x405 640x360 576x324 512x288 420x234 400x225 320x180
         create_res_4 2048x1152 1920x1080 1680x945 1440x810 1280x720 1024x576 960x540 840x472 800x450 640x360
         ;;
-    5)
+    6)
         create_res_1 3000x2000 2880x1920 2250x1500 1920x1280 1680x1050 1440x900 1280x800 1024x640
         create_res_2 1280x800 1280x720 960x600 960x540 640x360
         create_res_3 840x472 800x450 720x405 640x360 576x324 512x288 420x234 400x225 320x180
         create_res_4 1920x1280 1680x1050 1440x900 1280x800 1024x640 960x540 840x472 800x450 640x360
         ;;
-    6)
+    7)
         custom_res
         create_res_2 1360x765 1280x800 1280x720 960x600 960x540 640x360
         create_res_3 840x472 800x450 720x405 640x360 576x324 512x288 420x234 400x225 320x180


### PR DESCRIPTION
Add 1920x1280 resolution for the 3:2 display aspect ratio found on various 2-in-1 tablet devices such as the Microsoft Surface Go systems, the HP Elite X2 tablets and the Dell Latitude 5285 and 5290 2-in-1 computers.