### PR TITLE
fix: use /usr/bin/sed instead of sed

### DIFF
--- a/hidpi.sh
+++ b/hidpi.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 cat <<EEF
-  _    _   _____   _____    _____    _____ 
+  _    _   _____   _____    _____    _____
  | |  | | |_   _| |  __ \  |  __ \  |_   _|
- | |__| |   | |   | |  | | | |__) |   | |  
- |  __  |   | |   | |  | | |  ___/    | |  
- | |  | |  _| |_  | |__| | | |       _| |_ 
+ | |__| |   | |   | |  | | | |__) |   | |
+ |  __  |   | |   | |  | | |  ___/    | |
+ | |  | |  _| |_  | |__| | | |       _| |_
  |_|  |_| |_____| |_____/  |_|      |_____|
-                                           
+
 ============================================
 EEF
 
@@ -322,7 +322,7 @@ function init() {
     mbicon=${sysOverrides}"\/DisplayVendorID\-610\/DisplayProductID\-a028\-9d9da0\.tiff"
     lgicon=${sysOverrides}"\/DisplayVendorID\-1e6d\/DisplayProductID\-5b11\.tiff"
     proxdricon=${Overrides}"\/DisplayVendorID\-610\/DisplayProductID\-ae2f\_Landscape\.tiff"
-    
+
     if [[ $is_applesilicon == true ]]; then
         get_vidpid_applesilicon
     else
@@ -786,8 +786,8 @@ OOO
 function enable_hidpi() {
     choose_icon
     main
-    sed -i "" "/.*IODisplayEDID/d" ${dpiFile}
-    sed -i "" "/.*EDid/d" ${dpiFile}
+    /usr/bin/sed -i "" "/.*IODisplayEDID/d" ${dpiFile}
+    /usr/bin/sed -i "" "/.*EDid/d" ${dpiFile}
     end
 }
 


### PR DESCRIPTION
I've installed the gnu-sed in my system, run the `./hidpi.sh` failed with error below:


```bash
(4) 2560x1440 Display
(5) 3000x2000 Display
(6) 3440x1440 Display
(7) Manual input resolution

Enter your choice: 2
sed: can't read /.*IODisplayEDID/d: No such file or directory
sed: can't read /.*EDid/d: No such file or directory
```

and found we have use `/usr/bin/sed` in some places, so we should use `/usr/bin/sed` for the other places.