### PR TITLE
fix syntax in reading user defined custom resolution since the input should be coming in as an array

### DIFF
--- a/hidpi.sh
+++ b/hidpi.sh
@@ -716,8 +716,13 @@ function end() {
 # custom resolution
 function custom_res() {
     echo "${langCustomRes}"
-    read -p ":" res
-    create_res ${res}
+    read -p ":" input_resolutions
+    
+    # Split the input into an array
+    IFS=' ' read -r -a resolution_array <<< "$input_resolutions"
+    
+    # Call the create_res function with the array elements
+    create_res "${resolution_array[@]}"
 }
 
 # create resolution


### PR DESCRIPTION
Without this fix this is the error that I would get when inputting multiple resolution

```
------------------------------------------
|********** resolution config ***********|
------------------------------------------
(1) 1920x1080 Display
(2) 1920x1080 Display (use 1424x802, fix underscaled after sleep)
(3) 1920x1200 Display
(4) 2560x1440 Display
(5) 3000x2000 Display
(6) 3440x1440 Display
(7) Manual input resolution

Enter your choice: 7
Enter the HIDPI resolution, separated by a space，like this: 1680x945 1600x900 1440x810
:2549x1067 2580x1080 2150x900
/Users/user1/src/one-key-hidpi/hidpi.sh: line 728: 1067 2580 * 2: syntax error in expression (error token is "2580 * 2")
Enabled, please reboot.
Rebooting the logo for the first time will become huge, then it will not be.
```