### PR TITLE
Update hidpi.command

### DIFF
--- a/hidpi.command
+++ b/hidpi.command
@@ -2,5 +2,5 @@
 
 DIR="$( cd "$( dirname "$0"  )" && pwd  )"
 
-$DIR/hidpi.sh
+"$DIR/hidpi.sh"
 


### PR DESCRIPTION
Enclose command in double quotes to allow spaces within directory names.

Fixes #258